### PR TITLE
Pluggable flow aggregation function functionality added

### DIFF
--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -22,12 +22,15 @@ export interface ViewState {
 export type FlowAccessor<F, T> = (flow: F) => T; // objectInfo?: AccessorObjectInfo,
 export type LocationAccessor<L, T> = (location: L) => T;
 
+export type FlowAggregatorFunc<V, T> = (values: V) => T;
+
 export interface FlowAccessors<F> {
   getFlowOriginId: FlowAccessor<F, string | number>;
   getFlowDestId: FlowAccessor<F, string | number>;
   getFlowMagnitude: FlowAccessor<F, number>;
   getFlowTime?: FlowAccessor<F, Date>; // TODO: use number instead of Date
   // getFlowColor?: FlowAccessor<string | undefined>;
+  getFlowAggFunc: FlowAggregatorFunc<number[], number>;
 }
 
 export interface LocationAccessors<L> {
@@ -115,6 +118,7 @@ export interface AggregateFlow {
   dest: string | number;
   count: number;
   aggregate: true;
+  values: number[];
 }
 
 export function isAggregateFlow(
@@ -131,7 +135,7 @@ export function isAggregateFlow(
 
 export interface FlowCountsMapReduce<F, T = any> {
   map: (flow: F) => T;
-  reduce: (accumulated: T, val: T) => T;
+  reduce: (values: T) => T;
 }
 
 export enum LocationFilterMode {


### PR DESCRIPTION
As discussed this will allow the users to plug their own function to the flowmap layer via getFlowAggFunc.

Example would be below that averages rather than summing:

new FlowmapLayer<LocationDatum, FlowDatum>({
        id: 'my-flowmap-layer',
        data,
        opacity: config.opacity,
        pickable: true,
        darkMode: config.darkMode,
        colorScheme: config.colorScheme,
        fadeAmount: config.fadeAmount,
        fadeEnabled: config.fadeEnabled,
        fadeOpacityEnabled: config.fadeOpacityEnabled,
        locationTotalsEnabled: config.locationTotalsEnabled,
        locationLabelsEnabled: config.locationLabelsEnabled,
        animationEnabled: config.animationEnabled,
        clusteringEnabled: config.clusteringEnabled,
        clusteringAuto: config.clusteringAuto,
        clusteringLevel: config.clusteringLevel,
        adaptiveScalesEnabled: config.adaptiveScalesEnabled,
        highlightColor: config.highlightColor,
        maxTopFlowsDisplayNum: config.maxTopFlowsDisplayNum,
        getLocationId: (loc) => loc.id,
        getLocationLat: (loc) => loc.lat,
        getLocationLon: (loc) => loc.lon,
        getFlowOriginId: (flow) => flow.origin,
        getLocationName: (loc) => loc.name,
        getFlowDestId: (flow) => flow.dest,
        getFlowMagnitude: (flow) => flow.count,
        **getFlowAggFunc: (values) => values.reduce((a, b) => a + b, 0)/values.length,**
        onHover: (info) => setTooltip(getTooltipState(info)),
        onClick: (info) =>
          console.log('clicked', info.object?.type, info.object, info),
      });

Also, it defaults to sum when the function is not provided!